### PR TITLE
Include deep analyze results in report

### DIFF
--- a/src/task/deep-analyze-items/echo.item.ts
+++ b/src/task/deep-analyze-items/echo.item.ts
@@ -1,6 +1,8 @@
+import { Injectable } from '@nestjs/common';
 import { DeepAnalyzeItem } from '../stage-handlers/deep-analyze-item.interface';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
 
+@Injectable()
 export class EchoDeepAnalyzeItem implements DeepAnalyzeItem {
   readonly name = 'echo';
   readonly dependsOn = 'task-event-analyze' as const;


### PR DESCRIPTION
## Summary
- mark `EchoDeepAnalyzeItem` injectable
- inject deep analyze items into `ReportGenerationStageHandler`
- append deep analyze output in generated report

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852dd1626e88324b3f91f9c61a32b04