### PR TITLE
Add syllabus mapping in report

### DIFF
--- a/src/task/stage-handlers/report-generation.handler.ts
+++ b/src/task/stage-handlers/report-generation.handler.ts
@@ -24,6 +24,19 @@ export class ReportGenerationStageHandler implements TaskStageHandler {
     lines.push('# 课堂结构报告');
     lines.push('');
 
+    const syllabusContent = this.localStorage.readTextFileSafe(
+      taskId,
+      'mapped_syllabus.json',
+    );
+    if (syllabusContent) {
+      lines.push('## 教学目标映射结果');
+      lines.push('');
+      lines.push('```json');
+      lines.push(syllabusContent);
+      lines.push('```');
+      lines.push('');
+    }
+
     tasks.forEach((task: any, taskIndex: number) => {
       lines.push(`## 教学任务 ${taskIndex + 1}：${task.task_title}`);
       lines.push('');


### PR DESCRIPTION
## Summary
- show mapped syllabus JSON at the start of the final report

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852fce6425c8324b1c17a683d1f9707