### PR TITLE
Refactor sleep util

### DIFF
--- a/backend/src/task/deep-analyze-items/bloom.item.ts
+++ b/backend/src/task/deep-analyze-items/bloom.item.ts
@@ -4,7 +4,7 @@ import OpenAI from 'openai';
 import { DeepAnalyzeItem } from '../stage-handlers/deep-analyze-item.interface';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
 import { TaskEventAnalyzeStageHandler } from '../stage-handlers/task-event-analyze.stage-handler';
-import { extractLargestJsonBlock } from '../../utils';
+import { extractLargestJsonBlock, sleep } from '../../utils';
 import {
   TaskEventAnalyzeOutputSchema,
   BloomEventResult,
@@ -51,12 +51,12 @@ export class BloomDeepAnalyzeItem implements DeepAnalyzeItem {
           eventsOfTask.push(res);
           eventResults.push(res);
         }
-        await this.sleep(500);
+        await sleep(500);
       }
 
       const summary = await this.summarizeTask(task.task_title, eventsOfTask);
       if (summary) taskSummaries.push(summary);
-      await this.sleep(500);
+      await sleep(500);
     }
 
     const overall = await this.summarizeOverall(taskSummaries);
@@ -114,7 +114,7 @@ export class BloomDeepAnalyzeItem implements DeepAnalyzeItem {
         });
       } catch (err) {
         if (attempt === 3) console.error('Bloom analysis failed:', err);
-        await this.sleep(1000);
+        await sleep(1000);
       }
     }
 
@@ -158,7 +158,7 @@ export class BloomDeepAnalyzeItem implements DeepAnalyzeItem {
         return parsed;
       } catch (err) {
         if (attempt === 3) console.error('Bloom task summary failed:', err);
-        await this.sleep(1000);
+        await sleep(1000);
       }
     }
     return null;
@@ -187,13 +187,10 @@ export class BloomDeepAnalyzeItem implements DeepAnalyzeItem {
         return parsed;
       } catch (err) {
         if (attempt === 3) console.error('Bloom overall summary failed:', err);
-        await this.sleep(1000);
+        await sleep(1000);
       }
     }
     return null;
   }
 
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
 }

--- a/backend/src/task/deep-analyze-items/icap.item.ts
+++ b/backend/src/task/deep-analyze-items/icap.item.ts
@@ -4,7 +4,7 @@ import OpenAI from 'openai';
 import { DeepAnalyzeItem } from '../stage-handlers/deep-analyze-item.interface';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
 import { TaskEventAnalyzeStageHandler } from '../stage-handlers/task-event-analyze.stage-handler';
-import { extractLargestJsonBlock } from '../../utils';
+import { extractLargestJsonBlock, sleep } from '../../utils';
 import {
   TaskEventAnalyzeOutputSchema,
   ICAPAnalysis,
@@ -40,7 +40,7 @@ export class ICAPDeepAnalyzeItem implements DeepAnalyzeItem {
       for (const event of task.events || []) {
         const result = await this.analyzeEvent(event);
         if (result) results.push(result);
-        await this.sleep(500);
+        await sleep(500);
       }
     }
 
@@ -89,7 +89,7 @@ export class ICAPDeepAnalyzeItem implements DeepAnalyzeItem {
         });
       } catch (err) {
         if (attempt === 3) console.error('ICAP analysis failed:', err);
-        await this.sleep(1000);
+        await sleep(1000);
       }
     }
 
@@ -109,7 +109,4 @@ export class ICAPDeepAnalyzeItem implements DeepAnalyzeItem {
     return `事件类型：${event.event_type}\n事件摘要：${event.summary}\n片段内容：\n${lines.join('\n')}\n请根据以上信息判断该片段的 ICAP 模式，并按照要求输出 JSON。`;
   }
 
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
 }

--- a/backend/src/task/stage-handlers/task-event-analyze.stage-handler.ts
+++ b/backend/src/task/stage-handlers/task-event-analyze.stage-handler.ts
@@ -8,7 +8,7 @@ import { TaskStageHandler } from './stage-handler.interface';
 import { StageHandlerBase } from './stage-handler.base';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
 import { TranscriptProcessingStageHandler } from './transcript-processing.stage-handler';
-import { extractLargestJsonBlock } from '../../utils';
+import { extractLargestJsonBlock, sleep } from '../../utils';
 import { TaskStage } from '../task.types';
 import {
   TranscriptProcessingOutput,
@@ -96,7 +96,7 @@ export class TaskEventAnalyzeStageHandler
       fs.writeFileSync(cleanFilePath, JSON.stringify(parsed, null, 2), 'utf-8');
 
       allChunks.push(...parsed);
-      await this.sleep(1000); // rate limit buffer
+      await sleep(1000); // rate limit buffer
     }
 
     const validated = TaskEventAnalyzeOutputSchema.parse(allChunks);
@@ -150,7 +150,4 @@ ${JSON.stringify(chunk, null, 2)}
 - 最终只输出符合上述格式的 JSON，不要添加解释或注释。`;
   }
 
-  private sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  }
 }

--- a/backend/src/task/stage-handlers/transcript-processing.stage-handler.ts
+++ b/backend/src/task/stage-handlers/transcript-processing.stage-handler.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
 import { ConfigService } from '@nestjs/config';
-import { extractLargestJsonBlock } from '../../utils';
+import { extractLargestJsonBlock, sleep } from '../../utils';
 import { TaskStageHandler } from './stage-handler.interface';
 import { TaskStage } from '../task.types';
 import {
@@ -97,11 +97,11 @@ export class TranscriptProcessingStageHandler implements TaskStageHandler {
         } catch (err) {
           if (attempt === 3)
             console.error(`Batch ${i + 1} failed after 3 retries`, err);
-          await new Promise((r) => setTimeout(r, 5000));
+          await sleep(5000);
         }
       }
 
-      await new Promise((r) => setTimeout(r, 1000));
+      await sleep(1000);
     }
 
     const validated = TranscriptProcessingOutputSchema.parse(allResults);

--- a/backend/src/task/task-queue.service.ts
+++ b/backend/src/task/task-queue.service.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { TaskService } from './task.service';
+import { sleep } from '../utils';
 
 @Injectable()
 export class TaskQueueService {
@@ -24,7 +25,7 @@ export class TaskQueueService {
     while (true) {
       const task = this.queue.shift();
       if (!task) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await sleep(1000);
         continue;
       }
 

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -46,3 +46,7 @@ export function extractLargestJsonBlock(content: string): string | null {
 
   return best;
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- add a reusable `sleep` helper
- use `sleep` across task handlers and queue service

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685674f0da3c83249bfea4787afea39f