### PR TITLE
remove ModuleRef from stage handlers

### DIFF
--- a/backend/src/task/stage-handlers/deep-analyze.stage-handler.ts
+++ b/backend/src/task/stage-handlers/deep-analyze.stage-handler.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { LocalStorageService } from '../../local-storage/local-storage.service';
@@ -23,9 +22,8 @@ export class DeepAnalyzeStageHandler
     @Inject('DEEP_ANALYZE_ITEMS')
     @Optional()
     private readonly items: DeepAnalyzeItem[] = [],
-    private readonly moduleRef: ModuleRef,
   ) {
-    super(moduleRef);
+    super();
   }
 
   async handle(taskId: string): Promise<void> {

--- a/backend/src/task/stage-handlers/report-generation.handler.ts
+++ b/backend/src/task/stage-handlers/report-generation.handler.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import { TaskStageHandler } from './stage-handler.interface';
 import { StageHandlerBase } from './stage-handler.base';
 import { TaskEventAnalyzeStageHandler } from './task-event-analyze.stage-handler';
@@ -22,9 +21,8 @@ export class ReportGenerationStageHandler
     @Inject('DEEP_ANALYZE_ITEMS')
     @Optional()
     private readonly deepAnalyzeItems: DeepAnalyzeItem[] = [],
-    private readonly moduleRef: ModuleRef,
   ) {
-    super(moduleRef);
+    super();
   }
 
   async handle(taskId: string): Promise<void> {

--- a/backend/src/task/stage-handlers/stage-handler.base.ts
+++ b/backend/src/task/stage-handlers/stage-handler.base.ts
@@ -1,13 +1,13 @@
-import { ModuleRef } from '@nestjs/core';
 import { TaskStage } from '../task.types';
 import type { TaskStageHandler } from './stage-handler.interface';
 /**
  * Base class for all pipeline stage handlers.
  *
  * Concrete handlers such as `SyllabusMappingStageHandler` extend this class to
- * implement the TaskStageHandler interface. A {@link ModuleRef} instance is
- * injected so subclasses can look up other stage handlers at runtime based on
- * their class types declared in {@link dependsOn}.
+ * implement the TaskStageHandler interface. Dependency metadata is expressed
+ * via the static {@link dependsOn} property so handlers can read output files
+ * from other stages without relying on Nest's {@link ModuleRef} lookup at
+ * runtime.
  *
  * Stage metadata like {@link stage}, {@link outputFiles} and {@link dependsOn}
  * are defined as static properties so they can be read without creating an
@@ -23,7 +23,7 @@ export abstract class StageHandlerBase implements TaskStageHandler {
   static outputFiles?: string[];
   static dependsOn?: StageHandlerCtor[];
 
-  constructor(protected readonly moduleRef: ModuleRef) {}
+  constructor() {}
 
   get stage(): TaskStage {
     return (this.constructor as typeof StageHandlerBase).stage;
@@ -54,8 +54,8 @@ export abstract class StageHandlerBase implements TaskStageHandler {
     const deps = Array.isArray(stages) ? stages : [stages];
     const outputs: string[] = [];
     for (const dep of deps) {
-      const handler = this.moduleRef.get(dep, { strict: false });
-      if (handler?.outputFiles) outputs.push(...handler.outputFiles);
+      const files = (dep as any).outputFiles as string[] | undefined;
+      if (files) outputs.push(...files);
     }
     return outputs;
   }

--- a/backend/src/task/stage-handlers/syllabus.stage-handler.ts
+++ b/backend/src/task/stage-handlers/syllabus.stage-handler.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import OpenAI from 'openai';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -32,9 +31,8 @@ export class SyllabusMappingStageHandler
   constructor(
     private readonly localStorage: LocalStorageService,
     private readonly config: ConfigService,
-    private readonly moduleRef: ModuleRef,
   ) {
-    super(moduleRef);
+    super();
   }
 
   async handle(taskId: string): Promise<void> {

--- a/backend/src/task/stage-handlers/task-event-analyze.stage-handler.ts
+++ b/backend/src/task/stage-handlers/task-event-analyze.stage-handler.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { ModuleRef } from '@nestjs/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import OpenAI from 'openai';
@@ -29,9 +28,8 @@ export class TaskEventAnalyzeStageHandler
   constructor(
     private readonly localStorage: LocalStorageService,
     private readonly config: ConfigService,
-    private readonly moduleRef: ModuleRef,
   ) {
-    super(moduleRef);
+    super();
   }
 
   static stage: TaskStage = 'task-event-analyze';


### PR DESCRIPTION
## Summary
- simplify `StageHandlerBase` to read outputs directly from stage classes
- remove `ModuleRef` injection from stage handlers

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6856e6bc68a08324855135b4c5304447