### PR TITLE
Connect frontend to backend APIs

### DIFF
--- a/backend/src/task/task.controller.ts
+++ b/backend/src/task/task.controller.ts
@@ -9,6 +9,7 @@ import {
   Res,
   Sse,
   MessageEvent,
+  NotImplementedException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { TaskService } from './task.service';
@@ -67,6 +68,12 @@ export class TaskController {
     return buildTaskResponse(taskId);
   }
 
+  @Post('upload-audio')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAudio() {
+    throw new NotImplementedException('Audio upload not supported yet');
+  }
+
   // 4. Get status
   @Get(':taskId/status')
   getStatus(@Param('taskId') taskId: string) {
@@ -113,6 +120,21 @@ export class TaskController {
   @Get(':taskId/report')
   getReport(@Param('taskId') taskId: string) {
     return this.taskService.getTaskReport(taskId);
+  }
+
+  @Get(':taskId/report.pdf')
+  getReportPdf(@Param('taskId') _taskId: string) {
+    throw new NotImplementedException('PDF report generation not implemented');
+  }
+
+  @Get(':taskId/report.xlsx')
+  getReportXlsx(@Param('taskId') _taskId: string) {
+    throw new NotImplementedException('Excel report generation not implemented');
+  }
+
+  @Post(':taskId/share')
+  createShare(@Param('taskId') _taskId: string) {
+    throw new NotImplementedException('Share API not implemented');
   }
 
   // 7. List chunks

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -27,15 +27,10 @@ export async function uploadFile(
       ? makeUrl('/pipeline-task/upload-text')
       : makeUrl('/pipeline-task/upload');
 
-  try {
-    const res = await fetch(endpoint, { method: 'POST', body: form });
-    if (!res.ok) throw new Error('Request failed');
-    const data = await res.json();
-    return { taskId: data.id };
-  } catch (err) {
-    console.warn('Upload failed, using mock task ID:', err);
-    return { taskId: 'mock-task' };
-  }
+  const res = await fetch(endpoint, { method: 'POST', body: form });
+  if (!res.ok) throw new Error('Request failed');
+  const data = await res.json();
+  return { taskId: data.id };
 }
 
 export function streamProgress(
@@ -64,16 +59,11 @@ export async function fetchJson<T>(url: string): Promise<T> {
 }
 
 export async function fetchResult(taskId: string) {
-  try {
-    const [tasks, classInfo] = await Promise.all([
-      fetchJson(makeUrl(`/pipeline-task/${taskId}/result`)),
-      fetchJson(makeUrl(`/pipeline-task/${taskId}/class-info`)),
-    ]);
-    return { tasks, classInfo };
-  } catch (err) {
-    console.warn('Fetch result failed:', err);
-    return null;
-  }
+  const [tasks, classInfo] = await Promise.all([
+    fetchJson(makeUrl(`/pipeline-task/${taskId}/result`)),
+    fetchJson(makeUrl(`/pipeline-task/${taskId}/class-info`)),
+  ]);
+  return { tasks, classInfo };
 }
 
 export async function downloadFile(

--- a/frontend/src/components/ProcessingContainer.tsx
+++ b/frontend/src/components/ProcessingContainer.tsx
@@ -304,7 +304,7 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
 
     let es: EventSource | null = null;
 
-    if (taskId && taskId !== 'mock-task') {
+    if (taskId) {
       es = streamProgress(taskId, (data) => {
         const stageName = stageMap[data.stage];
         if (!stageName) {
@@ -347,77 +347,9 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
       };
     }
 
-    // Fallback to simulated progress for mock tasks
-    const processStages = async () => {
-      for (let i = 0; i < stages.length; i++) {
-        setCurrentStageIndex(i);
-
-        setStages((prev) =>
-          prev.map((stage, idx) => ({
-            ...stage,
-            status: idx === i ? 'processing' : stage.status,
-            startTime: idx === i ? Date.now() : stage.startTime,
-            isExpanded:
-              idx === i ? true : stage.status === 'completed' ? false : stage.isExpanded,
-          })),
-        );
-
-        for (let progress = 0; progress <= 100; progress += 20) {
-          await new Promise((resolve) => setTimeout(resolve, 400));
-
-          setStages((prev) =>
-            prev.map((stage, idx) => {
-              if (idx === i) {
-                const newLogs = [...stage.logs];
-                const stageSpecificLogs = getStageSpecificLogs(stage.name, progress);
-                newLogs.push(...stageSpecificLogs);
-
-                const details = getStageSpecificDetails(stage.name, progress);
-
-                return {
-                  ...stage,
-                  progress,
-                  logs: newLogs,
-                  details,
-                };
-              }
-              return stage;
-            }),
-          );
-        }
-
-        setStages((prev) =>
-          prev.map((stage, idx) =>
-            idx === i
-              ? {
-                  ...stage,
-                  status: 'completed',
-                  endTime: Date.now(),
-                  isExpanded: true,
-                }
-              : stage,
-          ),
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, 800));
-
-        setStages((prev) =>
-          prev.map((stage, idx) => (idx === i ? { ...stage, isExpanded: false } : stage)),
-        );
-
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      }
-
-      setCurrentStageIndex(-1);
-      setTimeout(() => {
-        setIsCollapsed(true);
-        onComplete();
-      }, 1000);
+    return () => {
+      if (es) es.close();
     };
-
-    processStages();
-
-    return () => {};
   }, [isProcessing, onComplete, taskId]);
 
   const getStatusIcon = (status: ProcessingStage['status']) => {

--- a/frontend/src/components/ReportActions.tsx
+++ b/frontend/src/components/ReportActions.tsx
@@ -31,13 +31,7 @@ export const ReportActions: React.FC<ReportActionsProps> = ({ analysisId, title 
         document.body.removeChild(element);
         URL.revokeObjectURL(url);
       } else {
-        // Fallback mock download
-        const element = document.createElement('a');
-        element.href = '#';
-        element.download = fileName;
-        document.body.appendChild(element);
-        element.click();
-        document.body.removeChild(element);
+        alert('Download failed.');
       }
     } catch (error) {
       console.error('Download failed:', error);

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -52,7 +52,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose, analysi
       setShareSettings(prev => ({ ...prev, url: res.url }));
       alert('Share link created successfully!');
     } else {
-      alert('Failed to create share link, using mock URL');
+      alert('Failed to create share link');
     }
   };
 


### PR DESCRIPTION
## Summary
- hook up `App` to real backend result data
- remove mock fallbacks in `api.ts`
- rely on SSE progress only in `ProcessingContainer`
- handle download/share failures politely
- add not-implemented API endpoints in backend controller

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a5a887f48324a2021978f632a6b3