### PR TITLE
Add env-configurable syllabus path

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,3 +1,4 @@
 OPENAI_API_KEY=sk-
 MODEL=gpt-4o
+SYLLABUS_ITEMS_PATH=src/assets/syllabus_items.json
 

--- a/backend/src/task/stage-handlers/syllabus.stage-handler.ts
+++ b/backend/src/task/stage-handlers/syllabus.stage-handler.ts
@@ -43,10 +43,10 @@ export class SyllabusMappingStageHandler
     );
     const tasks = TaskEventAnalyzeOutputSchema.parse(tasksRaw);
 
-    const syllabusPath = path.join(
-      __dirname,
-      '../../assets/syllabus_items.json',
-    );
+    const envPath = this.config.get<string>('SYLLABUS_ITEMS_PATH');
+    const syllabusPath = envPath
+      ? path.resolve(envPath)
+      : path.join(__dirname, '../../assets/syllabus_items.json');
     const syllabusItems = JSON.parse(fs.readFileSync(syllabusPath, 'utf-8'));
 
     const results: SyllabusMappingOutput = [];


### PR DESCRIPTION
## Summary
- add `SYLLABUS_ITEMS_PATH` to backend `.env.template`
- load syllabus items from the path specified in env or fallback to existing location

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6857a81d00188324a6871656b50a630b