### PR TITLE
Integrate frontend with backend task id

### DIFF
--- a/backend/src/task/task.controller.ts
+++ b/backend/src/task/task.controller.ts
@@ -90,6 +90,13 @@ export class TaskController {
     };
   }
 
+  // 4b. Get planned steps
+  @Get(':taskId/plan')
+  getPlan(@Param('taskId') taskId: string) {
+    const steps = this.taskService.getTaskPlan(taskId);
+    return { steps };
+  }
+
   @Sse(':taskId/events')
   progressStream(@Param('taskId') taskId: string) {
     return this.taskService

--- a/backend/src/task/task.service.ts
+++ b/backend/src/task/task.service.ts
@@ -43,6 +43,13 @@ export class TaskService {
       'queued',
     );
 
+    const plan = this.buildStepsForTask(taskId, 'json_transcript');
+    this.localStorage.saveFile(
+      taskId,
+      'plan.json',
+      JSON.stringify(plan.map((s) => s.name), null, 2),
+    );
+
     await this.taskQueue.enqueue({
       taskId,
       type: 'json_transcript',
@@ -71,6 +78,13 @@ export class TaskService {
       0,
       'Task created',
       'queued',
+    );
+
+    const plan = this.buildStepsForTask(taskId, 'txt_transcript');
+    this.localStorage.saveFile(
+      taskId,
+      'plan.json',
+      JSON.stringify(plan.map((s) => s.name), null, 2),
     );
 
     await this.taskQueue.enqueue({
@@ -148,6 +162,12 @@ export class TaskService {
 
   getClassInfo(taskId: string) {
     return this.localStorage.readJsonSafe(taskId, 'class_info.json');
+  }
+
+  getTaskPlan(taskId: string): string[] {
+    return (
+      this.localStorage.readJsonSafe(taskId, 'plan.json') || []
+    );
   }
 
   getTaskReport(taskId: string) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -101,3 +101,7 @@ export async function createShareLink(
     return null;
   }
 }
+
+export async function fetchTaskPlan(taskId: string): Promise<string[]> {
+  return fetchJson(`/pipeline-task/${taskId}/plan`).then((d: any) => d.steps);
+}

--- a/frontend/src/components/ProcessingContainer.tsx
+++ b/frontend/src/components/ProcessingContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ChevronUp, ChevronDown, CheckCircle, Clock, AlertCircle, Loader, Info, BarChart3, FileText, Brain } from 'lucide-react';
 import { ProcessingStage, ProcessingDetails } from '../types';
-import { streamProgress } from '../api';
+import { streamProgress, fetchTaskPlan } from '../api';
 
 interface ProcessingContainerProps {
   isProcessing: boolean;
@@ -75,6 +75,7 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
   
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [currentStageIndex, setCurrentStageIndex] = useState(-1);
+  const [plannedStepCount, setPlannedStepCount] = useState<number | null>(null);
 
   const stageOrder = [
     'File Processing',
@@ -85,6 +86,13 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
     'Engagement Analysis',
     'Report Generation',
   ];
+
+  useEffect(() => {
+    if (!taskId) return;
+    fetchTaskPlan(taskId)
+      .then((steps) => setPlannedStepCount(steps.length))
+      .catch(() => setPlannedStepCount(null));
+  }, [taskId]);
 
   const getStageIcon = (stageName: string) => {
     switch (stageName) {
@@ -366,7 +374,7 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
   };
 
   const completedStages = stages.filter(s => s.status === 'completed').length;
-  const totalStages = stages.length;
+  const totalStages = plannedStepCount ?? stages.length;
 
   if (!isProcessing && completedStages === 0) return null;
 
@@ -386,11 +394,13 @@ export const ProcessingContainer: React.FC<ProcessingContainerProps> = ({
           </div>
           <div>
             <h3 className="font-semibold text-gray-900">Analysis Processing</h3>
+            {taskId && (
+              <p className="text-xs text-gray-500 break-all">Task ID: {taskId}</p>
+            )}
             <p className="text-sm text-gray-600">
-              {completedStages === totalStages 
-                ? 'Analysis completed successfully' 
-                : `Processing stage ${currentStageIndex + 1} of ${totalStages}`
-              }
+              {completedStages === totalStages
+                ? 'Analysis completed successfully'
+                : `Processing stage ${currentStageIndex + 1} of ${totalStages}`}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show backend task id while processing
- expose backend API to retrieve task plan
- display planned steps in ProcessingContainer

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857aa8522f88324af6677f365d30320