### PR TITLE
Fix FlowStep type in runTask

### DIFF
--- a/backend/src/task/task.service.ts
+++ b/backend/src/task/task.service.ts
@@ -7,6 +7,7 @@ import {
   FlowRunnerService,
   FlowStep,
 } from './stage-handlers/flow-runner.service';
+import { TaskStage } from './task.types';
 import * as fs from 'fs';
 import * as archiver from 'archiver';
 import { Observable } from 'rxjs';
@@ -102,7 +103,7 @@ export class TaskService {
       let planNames = this.getTaskPlan(taskId);
       let steps: FlowStep[];
       if (planNames && planNames.length) {
-        steps = planNames.map((name) => ({ name }));
+        steps = planNames.map((name) => ({ name: name as TaskStage }));
       } else {
         steps = this.buildStepsForTask(taskId, type, true);
       }


### PR DESCRIPTION
## Summary
- correctly set `FlowStep` name as `TaskStage`

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run build --silent` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b01b39908324af6c368b1f3e7a32