### PR TITLE
Dynamic stage plan from backend

### DIFF
--- a/backend/src/task/task.controller.ts
+++ b/backend/src/task/task.controller.ts
@@ -17,6 +17,7 @@ import { CreateTaskDto } from './dto/create-task.dto';
 import { map } from 'rxjs/operators';
 import { buildTaskResponse } from './task-response.util';
 import { Response } from 'express';
+import { TaskStage, STAGE_LABELS } from './task.types';
 
 function parseDeepAnalyze(input: any): string[] | undefined {
   if (!input) return undefined;
@@ -93,8 +94,11 @@ export class TaskController {
   // 4b. Get planned steps
   @Get(':taskId/plan')
   getPlan(@Param('taskId') taskId: string) {
-    const steps = this.taskService.getTaskPlan(taskId);
-    return { steps };
+    const raw = this.taskService.getTaskPlan(taskId);
+    const steps = ['initializing', ...raw] as TaskStage[];
+    return {
+      steps: steps.map((s) => ({ id: s, label: STAGE_LABELS[s] || s })),
+    };
   }
 
   @Sse(':taskId/events')

--- a/backend/src/task/task.types.ts
+++ b/backend/src/task/task.types.ts
@@ -14,3 +14,14 @@ export interface TaskStatus {
   progress: number;
   message?: string;
 }
+
+export const STAGE_LABELS: Record<TaskStage, string> = {
+  initializing: 'File Processing',
+  transcript_preprocessing: 'File Processing',
+  'task-event-analyze': 'Task Segmentation',
+  syllabus_mapping: 'Class Information Detection',
+  deep_analyze: 'BLOOM Taxonomy Analysis',
+  report_generation: 'Report Generation',
+  done: 'Completed',
+  error: 'Error',
+};

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,8 @@ export interface UploadResponse {
   taskId: string;
 }
 
+import type { PlanStep } from './types';
+
 const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 function makeUrl(path: string): string {
@@ -102,6 +104,9 @@ export async function createShareLink(
   }
 }
 
-export async function fetchTaskPlan(taskId: string): Promise<string[]> {
-  return fetchJson(`/pipeline-task/${taskId}/plan`).then((d: any) => d.steps);
+
+export async function fetchTaskPlan(taskId: string): Promise<PlanStep[]> {
+  return fetchJson<{ steps: PlanStep[] }>(`/pipeline-task/${taskId}/plan`).then(
+    (d) => d.steps,
+  );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,11 @@ export interface AudioFile {
   type: 'audio' | 'transcript';
 }
 
+export interface PlanStep {
+  id: string;
+  label: string;
+}
+
 export interface ProcessingStage {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- provide label info for task stages in backend
- include initializing stage in `/plan` response
- expose `PlanStep` on frontend and adjust API
- load processing stages dynamically from backend

## Testing
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config)*
- `npm run build --prefix frontend`
- `npm run build --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6857b0b772948324b5c3ff97aea58f50