### PR TITLE
Fetch deep analysis items dynamically

### DIFF
--- a/backend/src/task/task.controller.ts
+++ b/backend/src/task/task.controller.ts
@@ -111,6 +111,11 @@ export class TaskController {
       .pipe(map((data) => ({ data }) as MessageEvent));
   }
 
+  @Get('deep-items')
+  listDeepItems() {
+    return { items: this.taskService.getDeepAnalyzeItems() };
+  }
+
   @Sse(':taskId/logs')
   logStream(@Param('taskId') taskId: string) {
     return this.taskService

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from 'react';
-import { FileUpload } from './components/FileUpload';
-import { ProcessingContainer } from './components/ProcessingContainer';
-import { ReportView } from './components/ReportView';
+import React, { useState } from "react";
+import { FileUpload } from "./components/FileUpload";
+import { ProcessingContainer } from "./components/ProcessingContainer";
+import { ReportView } from "./components/ReportView";
 import {
   AudioFile,
   AnalysisResult,
   ClassTask,
   ConversationEvent,
   ClassInfo,
-} from './types';
-import { uploadFile, fetchResult } from './api';
+} from "./types";
+import { uploadFile, fetchResult } from "./api";
 
 interface BackendSentence {
   start: number;
@@ -48,8 +48,8 @@ function transformResult(id: string, data: BackendResult): AnalysisResult {
         const role =
           (s.speaker_probabilities?.teacher ?? 0) >=
           (s.speaker_probabilities?.student ?? 0)
-            ? 'teacher'
-            : 'student';
+            ? "teacher"
+            : "student";
         events.push({
           id: `${tIdx}-${idx}-${events.length}`,
           role,
@@ -66,7 +66,7 @@ function transformResult(id: string, data: BackendResult): AnalysisResult {
     return {
       id: `t${tIdx}`,
       name: task.task_title,
-      description: task.summary || '',
+      description: task.summary || "",
       startTime: start === Infinity ? 0 : start,
       endTime: end,
       events,
@@ -79,9 +79,9 @@ function transformResult(id: string, data: BackendResult): AnalysisResult {
       const target = tasks[idx];
       if (!target) return;
       target.bloomAnalysis = {
-        level: summary.predominant_level || 'Remember',
+        level: summary.predominant_level || "Remember",
         confidence: 1,
-        description: summary.summary || '',
+        description: summary.summary || "",
         keywords: [],
       };
     });
@@ -89,18 +89,16 @@ function transformResult(id: string, data: BackendResult): AnalysisResult {
 
   const duration = tasks.reduce((max, t) => Math.max(max, t.endTime), 0);
 
+  const deepAnalysis: Record<string, boolean> = {};
+  if (data.bloom) deepAnalysis["bloom"] = true;
+
   return {
     id,
-    title: 'Class Analysis',
+    title: "Class Analysis",
     duration,
     classInfo: data.classInfo,
     tasks,
-    deepAnalysis: {
-      bloom: !!data.bloom,
-      sentiment: false,
-      engagement: false,
-      participation: false,
-    },
+    deepAnalysis,
   };
 }
 
@@ -129,7 +127,7 @@ function App() {
         const analysis = transformResult(taskId, result);
         setAnalysis(analysis);
       } catch (err) {
-        console.error('Failed to fetch result:', err);
+        console.error("Failed to fetch result:", err);
       }
     }
 
@@ -153,8 +151,9 @@ function App() {
             Class Audio Analyzer
           </h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Upload your class audio or transcript to get detailed analysis of learning activities, 
-            BLOOM taxonomy levels, and student engagement patterns.
+            Upload your class audio or transcript to get detailed analysis of
+            learning activities, BLOOM taxonomy levels, and student engagement
+            patterns.
           </p>
         </div>
 
@@ -175,7 +174,9 @@ function App() {
           {showReport && (
             <>
               <div className="flex justify-between items-center">
-                <h2 className="text-2xl font-semibold text-gray-900">Analysis Results</h2>
+                <h2 className="text-2xl font-semibold text-gray-900">
+                  Analysis Results
+                </h2>
                 <button
                   onClick={handleNewAnalysis}
                   className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
@@ -190,7 +191,10 @@ function App() {
 
         {/* Footer */}
         <div className="mt-16 text-center text-gray-500 text-sm">
-          <p>Powered by advanced AI analysis • Secure processing • Educational insights</p>
+          <p>
+            Powered by advanced AI analysis • Secure processing • Educational
+            insights
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,35 +2,35 @@ export interface UploadResponse {
   taskId: string;
 }
 
-import type { PlanStep } from './types';
+import type { PlanStep } from "./types";
 
-const API_BASE = import.meta.env.VITE_API_BASE || '';
+const API_BASE = import.meta.env.VITE_API_BASE || "";
 
 function makeUrl(path: string): string {
   if (!API_BASE) return path;
-  return API_BASE.replace(/\/$/, '') + path;
+  return API_BASE.replace(/\/$/, "") + path;
 }
 
 export async function uploadFile(
   file: File,
-  type: 'audio' | 'transcript',
+  type: "audio" | "transcript",
   deepAnalyze?: string[],
 ): Promise<UploadResponse> {
   const form = new FormData();
-  form.append('file', file);
+  form.append("file", file);
   if (deepAnalyze && deepAnalyze.length) {
-    form.append('deepAnalyze', deepAnalyze.join(','));
+    form.append("deepAnalyze", deepAnalyze.join(","));
   }
 
   const endpoint =
-    type === 'audio'
-      ? makeUrl('/pipeline-task/upload-audio')
-      : type === 'transcript'
-      ? makeUrl('/pipeline-task/upload-text')
-      : makeUrl('/pipeline-task/upload');
+    type === "audio"
+      ? makeUrl("/pipeline-task/upload-audio")
+      : type === "transcript"
+        ? makeUrl("/pipeline-task/upload-text")
+        : makeUrl("/pipeline-task/upload");
 
-  const res = await fetch(endpoint, { method: 'POST', body: form });
-  if (!res.ok) throw new Error('Request failed');
+  const res = await fetch(endpoint, { method: "POST", body: form });
+  if (!res.ok) throw new Error("Request failed");
   const data = await res.json();
   return { taskId: data.id };
 }
@@ -49,14 +49,14 @@ export function streamProgress(
     };
     return es;
   } catch (err) {
-    console.warn('SSE not available:', err);
+    console.warn("SSE not available:", err);
     return null;
   }
 }
 
 export async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(makeUrl(url));
-  if (!res.ok) throw new Error('Request failed');
+  if (!res.ok) throw new Error("Request failed");
   return res.json();
 }
 
@@ -71,18 +71,18 @@ export async function fetchResult(taskId: string) {
 
 export async function downloadFile(
   taskId: string,
-  format: 'pdf' | 'excel',
+  format: "pdf" | "excel",
 ): Promise<Blob | null> {
   const url =
-    format === 'pdf'
+    format === "pdf"
       ? makeUrl(`/pipeline-task/${taskId}/report.pdf`)
       : makeUrl(`/pipeline-task/${taskId}/report.xlsx`);
   try {
     const res = await fetch(url);
-    if (!res.ok) throw new Error('Failed');
+    if (!res.ok) throw new Error("Failed");
     return res.blob();
   } catch (err) {
-    console.warn('Download not available:', err);
+    console.warn("Download not available:", err);
     return null;
   }
 }
@@ -93,18 +93,17 @@ export async function createShareLink(
 ): Promise<{ url: string } | null> {
   try {
     const res = await fetch(makeUrl(`/pipeline-task/${taskId}/share`), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(settings),
     });
-    if (!res.ok) throw new Error('Failed');
+    if (!res.ok) throw new Error("Failed");
     return res.json();
   } catch (err) {
-    console.warn('Share link creation failed:', err);
+    console.warn("Share link creation failed:", err);
     return null;
   }
 }
-
 
 export async function fetchTaskPlan(taskId: string): Promise<PlanStep[]> {
   return fetchJson<{ steps: PlanStep[] }>(`/pipeline-task/${taskId}/plan`).then(
@@ -114,4 +113,14 @@ export async function fetchTaskPlan(taskId: string): Promise<PlanStep[]> {
 
 export async function fetchBloomAnalysis(taskId: string) {
   return fetchJson(`/pipeline-task/${taskId}/deep/bloom`);
+}
+
+export interface DeepItem {
+  name: string;
+}
+
+export async function fetchDeepItems(): Promise<DeepItem[]> {
+  return fetchJson<{ items: DeepItem[] }>(`/pipeline-task/deep-items`).then(
+    (d) => d.items,
+  );
 }

--- a/frontend/src/components/AnalysisControls.tsx
+++ b/frontend/src/components/AnalysisControls.tsx
@@ -1,95 +1,124 @@
-import React from 'react';
-import { Brain, Heart, Users, BarChart3 } from 'lucide-react';
+import React, { useEffect, useState } from "react";
+import { Brain, Heart, Users, BarChart3 } from "lucide-react";
+import { fetchDeepItems } from "../api";
 
 interface AnalysisControlsProps {
-  controls: {
-    bloom: boolean;
-    sentiment: boolean;
-    engagement: boolean;
-    participation: boolean;
-  };
-  onChange: (controls: any) => void;
+  controls: Record<string, boolean>;
+  onChange: (controls: Record<string, boolean>) => void;
 }
 
-export const AnalysisControls: React.FC<AnalysisControlsProps> = ({ controls, onChange }) => {
-  const handleToggle = (key: keyof typeof controls) => {
+export const AnalysisControls: React.FC<AnalysisControlsProps> = ({
+  controls,
+  onChange,
+}) => {
+  const [available, setAvailable] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetchDeepItems()
+      .then((items) => setAvailable(items.map((i) => i.name)))
+      .catch(() => setAvailable([]));
+  }, []);
+  const handleToggle = (key: string) => {
     onChange({
       ...controls,
-      [key]: !controls[key]
+      [key]: !controls[key],
     });
   };
 
-  const analysisTypes = [
+  const itemDetails: Record<
+    string,
     {
-      key: 'bloom' as const,
-      label: 'BLOOM Taxonomy',
-      description: 'Cognitive learning levels analysis',
-      icon: Brain,
-      color: 'text-purple-600 bg-purple-100 border-purple-200'
-    },
-    {
-      key: 'sentiment' as const,
-      label: 'Sentiment Analysis',
-      description: 'Emotional tone and engagement',
-      icon: Heart,
-      color: 'text-pink-600 bg-pink-100 border-pink-200'
-    },
-    {
-      key: 'engagement' as const,
-      label: 'Engagement Level',
-      description: 'Student participation metrics',
-      icon: BarChart3,
-      color: 'text-green-600 bg-green-100 border-green-200'
-    },
-    {
-      key: 'participation' as const,
-      label: 'Participation Pattern',
-      description: 'Speaking time and turn-taking',
-      icon: Users,
-      color: 'text-blue-600 bg-blue-100 border-blue-200'
+      label: string;
+      description: string;
+      icon: any;
+      color: string;
     }
-  ];
+  > = {
+    bloom: {
+      label: "BLOOM Taxonomy",
+      description: "Cognitive learning levels analysis",
+      icon: Brain,
+      color: "text-purple-600 bg-purple-100 border-purple-200",
+    },
+    sentiment: {
+      label: "Sentiment Analysis",
+      description: "Emotional tone and engagement",
+      icon: Heart,
+      color: "text-pink-600 bg-pink-100 border-pink-200",
+    },
+    engagement: {
+      label: "Engagement Level",
+      description: "Student participation metrics",
+      icon: BarChart3,
+      color: "text-green-600 bg-green-100 border-green-200",
+    },
+    participation: {
+      label: "Participation Pattern",
+      description: "Speaking time and turn-taking",
+      icon: Users,
+      color: "text-blue-600 bg-blue-100 border-blue-200",
+    },
+  };
+
+  const analysisTypes = available
+    .map((name) => ({ key: name, ...itemDetails[name] }))
+    .filter((i) => i.label);
 
   return (
     <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-200">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">Deep Analysis Controls</h3>
-      
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        Deep Analysis Controls
+      </h3>
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {analysisTypes.map((analysis) => {
           const Icon = analysis.icon;
           const isActive = controls[analysis.key];
-          
+
           return (
             <div
               key={analysis.key}
               className={`border-2 rounded-lg p-4 cursor-pointer transition-all ${
-                isActive 
-                  ? analysis.color + ' shadow-md'
-                  : 'border-gray-200 hover:border-gray-300 bg-gray-50'
+                isActive
+                  ? analysis.color + " shadow-md"
+                  : "border-gray-200 hover:border-gray-300 bg-gray-50"
               }`}
               onClick={() => handleToggle(analysis.key)}
             >
               <div className="flex items-start space-x-3">
-                <div className={`p-2 rounded-lg ${isActive ? 'bg-white' : 'bg-gray-200'}`}>
-                  <Icon className={`w-5 h-5 ${isActive ? analysis.color.split(' ')[0] : 'text-gray-500'}`} />
+                <div
+                  className={`p-2 rounded-lg ${isActive ? "bg-white" : "bg-gray-200"}`}
+                >
+                  <Icon
+                    className={`w-5 h-5 ${isActive ? analysis.color.split(" ")[0] : "text-gray-500"}`}
+                  />
                 </div>
-                
+
                 <div className="flex-1">
                   <div className="flex items-center justify-between">
-                    <h4 className="font-medium text-gray-900">{analysis.label}</h4>
-                    <div className={`w-4 h-4 border-2 rounded ${
-                      isActive 
-                        ? 'bg-current border-current' 
-                        : 'border-gray-300'
-                    }`}>
+                    <h4 className="font-medium text-gray-900">
+                      {analysis.label}
+                    </h4>
+                    <div
+                      className={`w-4 h-4 border-2 rounded ${
+                        isActive
+                          ? "bg-current border-current"
+                          : "border-gray-300"
+                      }`}
+                    >
                       {isActive && (
-                        <svg viewBox="0 0 16 16" className="w-full h-full text-white fill-current">
-                          <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
+                        <svg
+                          viewBox="0 0 16 16"
+                          className="w-full h-full text-white fill-current"
+                        >
+                          <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z" />
                         </svg>
                       )}
                     </div>
                   </div>
-                  <p className="text-sm text-gray-600 mt-1">{analysis.description}</p>
+                  <p className="text-sm text-gray-600 mt-1">
+                    {analysis.description}
+                  </p>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/ReportView.tsx
+++ b/frontend/src/components/ReportView.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import { AnalysisResult, ClassTask } from '../types';
-import { AudioPlayer } from './AudioPlayer';
-import { TaskItem } from './TaskItem';
-import { AnalysisControls } from './AnalysisControls';
-import { ClassInfoCard } from './ClassInfoCard';
-import { ReportActions } from './ReportActions';
+import React, { useState } from "react";
+import { AnalysisResult, ClassTask } from "../types";
+import { AudioPlayer } from "./AudioPlayer";
+import { TaskItem } from "./TaskItem";
+import { AnalysisControls } from "./AnalysisControls";
+import { ClassInfoCard } from "./ClassInfoCard";
+import { ReportActions } from "./ReportActions";
 
 interface ReportViewProps {
   analysisResult: AnalysisResult;
@@ -12,7 +12,9 @@ interface ReportViewProps {
 
 export const ReportView: React.FC<ReportViewProps> = ({ analysisResult }) => {
   const [selectedTaskId, setSelectedTaskId] = useState<string>();
-  const [analysisControls, setAnalysisControls] = useState(analysisResult.deepAnalysis);
+  const [analysisControls, setAnalysisControls] = useState<
+    Record<string, boolean>
+  >(analysisResult.deepAnalysis);
 
   const handleTaskSelect = (task: ClassTask) => {
     setSelectedTaskId(task.id);
@@ -26,31 +28,38 @@ export const ReportView: React.FC<ReportViewProps> = ({ analysisResult }) => {
           <div className="flex-1">
             <h2 className="text-2xl font-bold mb-2">Class Analysis Report</h2>
             <p className="text-blue-100">
-              Analysis completed for {analysisResult.title} • Duration: {Math.floor(analysisResult.duration / 60)}:{String(analysisResult.duration % 60).padStart(2, '0')}
+              Analysis completed for {analysisResult.title} • Duration:{" "}
+              {Math.floor(analysisResult.duration / 60)}:
+              {String(analysisResult.duration % 60).padStart(2, "0")}
             </p>
             <div className="flex space-x-6 mt-4">
               <div className="text-center">
-                <div className="text-2xl font-bold">{analysisResult.tasks.length}</div>
+                <div className="text-2xl font-bold">
+                  {analysisResult.tasks.length}
+                </div>
                 <div className="text-sm text-blue-200">Tasks Identified</div>
               </div>
               <div className="text-center">
                 <div className="text-2xl font-bold">
-                  {analysisResult.tasks.reduce((sum, task) => sum + task.events.length, 0)}
+                  {analysisResult.tasks.reduce(
+                    (sum, task) => sum + task.events.length,
+                    0,
+                  )}
                 </div>
                 <div className="text-sm text-blue-200">Conversation Events</div>
               </div>
               <div className="text-center">
                 <div className="text-2xl font-bold">
-                  {analysisResult.tasks.filter(t => t.bloomAnalysis).length}
+                  {analysisResult.tasks.filter((t) => t.bloomAnalysis).length}
                 </div>
                 <div className="text-sm text-blue-200">BLOOM Analyzed</div>
               </div>
             </div>
           </div>
-          
+
           {/* Action Buttons */}
           <div className="ml-6">
-            <ReportActions 
+            <ReportActions
               analysisId={analysisResult.id}
               title={analysisResult.title}
             />
@@ -76,14 +85,16 @@ export const ReportView: React.FC<ReportViewProps> = ({ analysisResult }) => {
 
       {/* Tasks List */}
       <div className="bg-white rounded-xl shadow-lg p-6 border border-gray-200">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Class Tasks & Events</h3>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Class Tasks & Events
+        </h3>
         <div className="space-y-4">
           {analysisResult.tasks.map((task) => (
             <TaskItem
               key={task.id}
               task={task}
               isSelected={selectedTaskId === task.id}
-              showBloomAnalysis={analysisControls.bloom}
+              showBloomAnalysis={analysisControls["bloom"]}
               onTaskClick={handleTaskSelect}
             />
           ))}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface AudioFile {
   file: File;
-  type: 'audio' | 'transcript';
+  type: "audio" | "transcript";
 }
 
 export interface PlanStep {
@@ -11,7 +11,7 @@ export interface PlanStep {
 export interface ProcessingStage {
   id: string;
   name: string;
-  status: 'pending' | 'processing' | 'completed' | 'error';
+  status: "pending" | "processing" | "completed" | "error";
   progress: number;
   logs: string[];
   startTime?: number;
@@ -31,7 +31,7 @@ export interface ProcessingDetails {
 
 export interface ConversationEvent {
   id: string;
-  role: 'teacher' | 'student' | 'system';
+  role: "teacher" | "student" | "system";
   text: string;
   startTime: number;
   endTime: number;
@@ -49,7 +49,13 @@ export interface ClassTask {
 }
 
 export interface BloomAnalysis {
-  level: 'Remember' | 'Understand' | 'Apply' | 'Analyze' | 'Evaluate' | 'Create';
+  level:
+    | "Remember"
+    | "Understand"
+    | "Apply"
+    | "Analyze"
+    | "Evaluate"
+    | "Create";
   confidence: number;
   description: string;
   keywords: string[];
@@ -70,12 +76,7 @@ export interface AnalysisResult {
   duration: number;
   classInfo: ClassInfo;
   tasks: ClassTask[];
-  deepAnalysis: {
-    bloom: boolean;
-    sentiment: boolean;
-    engagement: boolean;
-    participation: boolean;
-  };
+  deepAnalysis: Record<string, boolean>;
 }
 
 export interface ShareSettings {


### PR DESCRIPTION
## Summary
- expose available deep analysis items from backend
- look up deep analysis results by item name
- fetch deep analysis item list in the frontend
- support dynamic deep analysis controls
- adjust data types for dynamic analysis flags

## Testing
- `npx tsc -p tsconfig.json` *(frontend)*
- `npx tsc -p tsconfig.build.json` *(backend, fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6857cefeb2fc8324946f5cbe67d00324